### PR TITLE
File Error in extract process

### DIFF
--- a/tasks/xliff.js
+++ b/tasks/xliff.js
@@ -10,9 +10,11 @@ module.exports = function(grunt) {
 
         var options = this.options({languages: ["en"]});
         grunt.verbose.writeflags(options, 'Options');
-      
-      var other = grunt.file.readJSON(options.extra);
-        
+
+        if (options.extra && !grunt.file.exists(options.extra)) {
+           other = grunt.file.readJSON(options.extra);
+        }
+
         grunt.util.async.forEachSeries(this.files, function(f, nextFileObj) {
             var files = f.src.filter(function(filepath) {
                 // Warn on and remove invalid source files (if nonull was set).

--- a/tasks/xliff.js
+++ b/tasks/xliff.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
         var options = this.options({languages: ["en"]});
         grunt.verbose.writeflags(options, 'Options');
 
+        var other = {};
         if (options.extra && !grunt.file.exists(options.extra)) {
            other = grunt.file.readJSON(options.extra);
         }


### PR DESCRIPTION
Looking over the documentation, I do not see anything referring to options.extra being required. Given this, I've wrapped the options.extra file read in a logic check to avoid a failure, as shown below, when you don't set it.

madzak$ grunt xliff
Running "xliff:export" (xliff) task
Warning: Unable to read "undefined" file (Error code: ENOENT). Use --force to continue.
