### PR TITLE
If there's other variable without I18n helper in template, error occurs.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -79,7 +79,7 @@ module.exports = function(options){
         i18n.setLocale(currLang);
         for(var k=0;k<handlebarsTemplates.length;k++){
             //we don't need to keep this result
-            var result = handlebarsTemplates[k](options.translations[currLang]);
+            var result = handlebarsTemplates[k](options.translations[currLang] || {});
             
         }
     }


### PR DESCRIPTION
If there's other variable without I18n helper in template, error occurs.
Fix by falling back empty translation context into a plain object.

**Temaplte**:

```
<p>{{ I18n 'This is a test.' }}</p><p>{{ I18n 'This is another test' }}</p>
{{ test }}
```

**Error message**:

```
Warning: Cannot read property 'test' of undefined Use --force to continue.
```
