### PR TITLE
Fix to support I18n string contains "{" or "}" character

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -80,15 +80,16 @@ module.exports = function(options){
         for (var k = 0; k < options.templateList.length; k++) {
             // parse I18n string from each Handlebars template
             var template = options.templateList[k],
-                i18nPatStr = "\\{\\{\\s*I18n\\s+['\"]{1}([^{}]+)['\"]{1}\\s*\\}\\}",
-                match = template.match(new RegExp(i18nPatStr, 'gm')),
+                i18nPat = /\{\{\s*I18n\s+(['"])(.+?)([^\\])\1/gm,
+                match = template.match(i18nPat),
                 m,
                 str,
                 transStr;
             if (match) {
                 while (match.length > 0) {
-                    m = new RegExp(i18nPatStr).exec(match.pop());
-                    if (str = m && m[1]) {
+                    m = new RegExp(i18nPat.source).exec(match.pop());
+                    if (m) {
+                        str = m.splice(2).join('');
                         transStr = (i18n !== undefined ? i18n.__(str) : str);
                         translations[currLang][str] = transStr;
                     }


### PR DESCRIPTION
In current version, I18n string contains `{` or `}` character will be ignored. Modify regular expression to fix this problem.
