### PR TITLE
Remove backslash escaping while extracing i18n string

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -90,6 +90,7 @@ module.exports = function(options){
                     m = new RegExp(i18nPat.source).exec(match.pop());
                     if (m) {
                         str = m.splice(2).join('');
+                        str = eval('"' + str + '"'); // remove backslash escaping
                         transStr = (i18n !== undefined ? i18n.__(str) : str);
                         translations[currLang][str] = transStr;
                     }


### PR DESCRIPTION
If there source string contains backslash escaping, the backslash character should not be part of extracted string.
For example:

```
{{ I18n "This is an \"example\" for this issue." }}
```

There will be some redundant backslashes in JSON file:

```
{
    "This is an \\\"example\\\" for this issue.": "This is an \\\"example\\\" for this issue."
}
```
